### PR TITLE
chore(deps): bump netty-common from 4.1.114 to 4.1.115

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
 kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor" }
 micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
+netty-common = "io.netty:netty-common:4.1.115.Final"
 reactor-kotlin-extensions = { module = "io.projectreactor.kotlin:reactor-kotlin-extensions" }
 reactor-test = { module = "io.projectreactor:reactor-test" }
 spring-boot-devtools = { module = "org.springframework.boot:spring-boot-devtools" }


### PR DESCRIPTION
pinned the version of netty-common, in order to fix CVE-2024-47535.

Refs: https://github.com/digitalservicebund/kotlin-application-template/security/code-scanning/148