### PR TITLE
chore(deps): bump netty-common from 4.1.114 to 4.1.115

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(libs.kotlin.reflect)
     implementation(libs.kotlin.stdlib.jdk8)
     implementation(libs.kotlinx.coroutines.reactor)
+    implementation(libs.netty.common)
 
     runtimeOnly(libs.micrometer.registry.prometheus)
 


### PR DESCRIPTION
pinned the version of netty-common, in order to fix CVE-2024-47535.

Refs: https://github.com/digitalservicebund/kotlin-application-template/security/code-scanning/148