### PR TITLE
build(deps): bump com.diffplug.spotless from 6.25.0 to 7.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,10 +198,10 @@ sonar {
 
 spotless {
     kotlin {
-        ktlint("1.5.0")
+        ktlint()
     }
     kotlinGradle {
-        ktlint("1.5.0")
+        ktlint()
     }
     format("misc") {
         target(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ dependency-license-report = "com.github.jk1.dependency-license-report:2.9"
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
 sonarqube = "org.sonarqube:6.0.1.5171"
-spotless = "com.diffplug.spotless:6.25.0"
+spotless = "com.diffplug.spotless:7.0.0"
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
 spring-dependency-management = "io.spring.dependency-management:1.1.7"
 test-logger = "com.adarshr.test-logger:4.0.0"


### PR DESCRIPTION
and remove the version of klint from build.gradle.kts since the version 1.5.0 of klint is already used in the version 7.0.0 of the spotless gradle plugin (ref. https://github.com/diffplug/spotless/releases/tag/gradle%2F7.0.0)