### PR TITLE
Potential fix for code scanning alert no. 209: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,6 +40,8 @@ jobs:
 
   audit-licenses:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - name: Set up JDK


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/kotlin-application-template/security/code-scanning/209](https://github.com/digitalservicebund/kotlin-application-template/security/code-scanning/209)

To fix the permissions issue, add an explicit `permissions` block to the `audit-licenses` job in `.github/workflows/pipeline.yml`, setting it to the minimum required for the job to work—typically `contents: read`. Insert the following:
```yaml
permissions:
  contents: read
```
as the first key under the job (immediately after `runs-on`). No other changes are necessary as this job only checks out code and runs local license checks without writing to the repository or related resources.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
