### PR TITLE
Potential fix for code scanning alert no. 207: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/kotlin-application-template/security/code-scanning/207](https://github.com/digitalservicebund/kotlin-application-template/security/code-scanning/207)

The best way to fix the problem is to add a `permissions` block to the job definition, so that the GITHUB_TOKEN provided to the job has only the minimal access required. For secret scanning and notification purposes, usually only `contents: read` is required unless the notification action or scanning tool requires additional access. The correct region to change in the code is to add the following block at the same level as `runs-on:` in the `check` job under `jobs:` in `.github/workflows/secrets-check.yml`.

No external dependencies or imports are required because this is a configuration change in YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
