### PR TITLE
Potential fix for code scanning alert no. 179: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -114,6 +114,8 @@ jobs:
 
   analyze:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ github.ref == 'refs/heads/main' }}
     needs: [build, vulnerability-scan]
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/kotlin-application-template/security/code-scanning/179](https://github.com/digitalservicebund/kotlin-application-template/security/code-scanning/179)

To fix the problem, you should add a `permissions` block to the `analyze` job in the workflow YAML file. The most minimal starting point recommended is `contents: read`, which allows the job to read the repository contents but not write to it or perform other potentially risky operations. This does not negatively affect the workflow, as all the visible steps depend only on reading source code and uploading results to third-party services, not interacting with the repo state.  
Specifically, in `.github/workflows/pipeline.yml`, insert:

```yaml
permissions:
  contents: read
```

under the `analyze:` job definition (between line 116 and line 117, immediately after `runs-on: ubuntu-latest`).  
No imports or external method calls are needed—just add the appropriate YAML lines in the correct place.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
