### PR TITLE
Potential fix for code scanning alert no. 208: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,6 +21,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - name: Set up JDK


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/kotlin-application-template/security/code-scanning/208](https://github.com/digitalservicebund/kotlin-application-template/security/code-scanning/208)

To fix this issue, we need to explicitly add a `permissions` block to the `build` job in the workflow file at `.github/workflows/pipeline.yml`. We should grant only the minimum permissions necessary for the job to execute successfully. The build job checks out code (requires `contents: read`) and sends status notifications to Slack (via an action that does not require GitHub repository permissions). Begin with the following permissions:

```yaml
permissions:
  contents: read
```

This should be added to the YAML block for the `build` job alongside `runs-on: ubuntu-latest`. No additional dependencies or imports or further changes are required, as this is only a YAML configuration update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
