### PR TITLE
Potential fix for code scanning alert no. 180: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -211,6 +211,7 @@ jobs:
 
   deploy-staging:
     runs-on: ubuntu-latest
+    permissions: {}
     # Remove the filter on github.repository when using this template
     if: ${{ github.ref == 'refs/heads/main' && github.repository == 'digitalservicebund/kotlin-application-template' }}
     environment: staging


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/kotlin-application-template/security/code-scanning/180](https://github.com/digitalservicebund/kotlin-application-template/security/code-scanning/180)

To fix the problem, an explicit `permissions` block should be added to the `deploy-staging` job, specifying the minimum necessary token permissions for its steps. If the job does not require access to repository contents or other resources via the GITHUB_TOKEN, set `permissions: {}` (an empty block) to disable all permissions. Otherwise, enumerate only those permissions that are required. Because the job appears to only interact with third-party deploy actions and uses repository secrets, it likely does not need any GitHub API access. Therefore, use `permissions: {}` as a minimal baseline. Make this change at line 213, directly under `runs-on:` and before `if:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
